### PR TITLE
Headers set to None are now omitted in request.

### DIFF
--- a/requesocks/models.py
+++ b/requesocks/models.py
@@ -161,6 +161,11 @@ class Request(object):
             if k not in headers:
                 headers[k] = v
 
+        # Remove headers set to None.
+        for (k, v) in list(headers.items()):
+            if v is None:
+                del headers[k]
+
         self.headers = headers
         self._poolmanager = _poolmanager
 

--- a/requesocks/sessions.py
+++ b/requesocks/sessions.py
@@ -18,8 +18,6 @@ from .packages.urllib3.poolmanager import PoolManager
 
 def merge_kwargs(local_kwarg, default_kwarg):
     """Merges kwarg dictionaries.
-
-    If a local key in the dictionary is set to None, it will be removed.
     """
 
     if default_kwarg is None:
@@ -38,11 +36,6 @@ def merge_kwargs(local_kwarg, default_kwarg):
     # Update new values.
     kwargs = default_kwarg.copy()
     kwargs.update(local_kwarg)
-
-    # Remove keys that are set to None.
-    for (k, v) in list(local_kwarg.items()):
-        if v is None:
-            del kwargs[k]
 
     return kwargs
 


### PR DESCRIPTION
If a request header is set to None, it should be omitted from the request.

However, the following example results in the header "User-Agent: None" being sent:

session = requests.session()
session.headers = {'User-Agent': None}
session.proxies = {...}
resp = session.get('http://example.org')

Similarly, the following example results in the header "User-Agent: python-requests/0.10.8" being sent:

r = requests.get(url, proxies=proxies, headers={'User-Agent': None})

The pull request restores the expected "requests" behavior and omits headers which are set to None.
