### PR TITLE
Request: Addition of Session.close()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+Fork of github.com/foxx/requests == python-requests *working with socks proxy* (i.e tor).
+Just renamed the package to allow simultaneously use of original reuests and socks-capable requests.
+
 Requests: HTTP for Humans
 =========================
 


### PR DESCRIPTION
Is there a reason why the .close() has yet to be implemented, the equivalent of the .close() from the original requests library? To ensure the session is closed, without leaving any open/dead/hanging/zombie sockets, would a Session.close() be the way to avoid having socket nightmares on a multi-threaded crawler utilizing requesocks.Session()?

Trying to do:

```
sesh = requesocks.Session()

# do stuff

sesh.close()
```

From requests:

```
     def close(self):
        """Closes all adapters and as such the session"""
        for v in self.adapters.values():
            v.close()
```

Thanks!
