### PR TITLE
Update __init__.py

### DIFF
--- a/requesocks/packages/urllib3/packages/socksipy/__init__.py
+++ b/requesocks/packages/urllib3/packages/socksipy/__init__.py
@@ -1,2 +1,2 @@
 import socks
-import socksipyhandler
+import sockshandler


### PR DESCRIPTION
modify the socksipyhandler -> sockshandler;
Because, requesocks depend on SocksiPy, but SocksiPy Official version can't support Python3.x, so we can use a alternative PySocks(it's a modern fork of SocksiPy, https://github.com/Anorov/PySocks). While, the PySocks use "sockshandler" package.